### PR TITLE
bump version of arcus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cuenca/python:0.0.1
+FROM python:3.7
 LABEL maintainer="dev@cuenca.com"
 
 # Install app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-arcus==1.2.2
+arcus==1.2.4
 celery==4.4.6
 pymongo==3.10.1
 sentry-sdk==0.16.0
 requests==2.24.0
 click==7.1.2
-dataclasses
 newrelic==5.14.1.144


### PR DESCRIPTION
- bump version of `arcus`
- upgrade to python 3.7
- remove `dataclasses` as a requirement since